### PR TITLE
Payroll src and tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  FOUNDRY_PROFILE: ci
+
+jobs:
+  check:
+    name: Foundry project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Show Forge version
+        run: |
+          forge --version
+
+      - name: Run Forge fmt
+        run: |
+          forge fmt --check
+        id: fmt
+
+      - name: Run Forge build
+        run: |
+          forge build --sizes
+        id: build
+
+      - name: Run Forge tests
+        run: |
+          forge test -vvv
+        id: test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Compiler files
+cache/
+out/
+
+# Ignores development broadcast logs
+!/broadcast
+/broadcast/*/31337/
+/broadcast/**/dry-run/
+
+# Docs
+docs/
+
+# Dotenv file
+.env

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/forge-std"]
+	path = lib/forge-std
+	url = https://github.com/foundry-rs/forge-std

--- a/README.md
+++ b/README.md
@@ -1,1 +1,66 @@
-# payroll
+## Foundry
+
+**Foundry is a blazing fast, portable and modular toolkit for Ethereum application development written in Rust.**
+
+Foundry consists of:
+
+- **Forge**: Ethereum testing framework (like Truffle, Hardhat and DappTools).
+- **Cast**: Swiss army knife for interacting with EVM smart contracts, sending transactions and getting chain data.
+- **Anvil**: Local Ethereum node, akin to Ganache, Hardhat Network.
+- **Chisel**: Fast, utilitarian, and verbose solidity REPL.
+
+## Documentation
+
+https://book.getfoundry.sh/
+
+## Usage
+
+### Build
+
+```shell
+$ forge build
+```
+
+### Test
+
+```shell
+$ forge test
+```
+
+### Format
+
+```shell
+$ forge fmt
+```
+
+### Gas Snapshots
+
+```shell
+$ forge snapshot
+```
+
+### Anvil
+
+```shell
+$ anvil
+```
+
+### Deploy
+
+```shell
+$ forge script script/Counter.s.sol:CounterScript --rpc-url <your_rpc_url> --private-key <your_private_key>
+```
+
+### Cast
+
+```shell
+$ cast <subcommand>
+```
+
+### Help
+
+```shell
+$ forge --help
+$ anvil --help
+$ cast --help
+```

--- a/foundry.lock
+++ b/foundry.lock
@@ -1,0 +1,8 @@
+{
+  "lib/forge-std": {
+    "tag": {
+      "name": "v1.10.0",
+      "rev": "8bbcf6e3f8f62f419e5429a0bd89331c85c37824"
+    }
+  }
+}

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,9 @@
+[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+
+[lint]
+severity = ["high"]
+
+# See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/script/Payroll.s.sol
+++ b/script/Payroll.s.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Script} from "forge-std/Script.sol";
+import {Payroll} from "../src/Payroll.sol";
+
+contract CounterScript is Script {
+    Payroll public payroll;
+
+    function setUp() public {}
+
+    function run() public {
+        vm.startBroadcast();
+
+        //payroll = new Payroll();
+
+        vm.stopBroadcast();
+    }
+}

--- a/src/Payroll.sol
+++ b/src/Payroll.sol
@@ -70,14 +70,14 @@ contract Payroll {
     /**
     * @notice withdraw salary
     */
-    function withdraw() external {
+    function withdraw(uint256 amount) external {
         updateRecipient(msg.sender);
 
-        uint256 amount = unclaimed[msg.sender];
-        unclaimed[msg.sender] = 0;        
-        require(DOLA.transferFrom(treasuryAddress, msg.sender, amount), "DolaPayroll::withdraw: transfer failed");
+        uint256 withdrawAmount = unclaimed[msg.sender] > amount ? amount : unclaimed[msg.sender];
+        unclaimed[msg.sender] -= withdrawAmount;
+        require(DOLA.transferFrom(treasuryAddress, msg.sender, withdrawAmount), "DolaPayroll::withdraw: transfer failed");
 
-        emit AmountWithdrawn(msg.sender, amount);
+        emit AmountWithdrawn(msg.sender, withdrawAmount);
     }
 
 }

--- a/src/Payroll.sol
+++ b/src/Payroll.sol
@@ -2,8 +2,10 @@ pragma solidity 0.8.13;
 
 interface IERC20 {
     function transferFrom(address from, address to, uint256 amount) external returns (bool);
+    function decimals() external view returns (uint8);
 }
 
+// WARNING: THIS CONTRACT IS NOT COMPATIBLE WITH NON-STANDARD ERC20 TOKENS (e.g. USDT)
 contract Payroll {
 
     mapping(address => Recipient) public recipients;
@@ -25,6 +27,7 @@ contract Payroll {
     event AmountWithdrawn(address recipient, uint256 amount);
 
     constructor(address _treasuryAddress, address _governance, address _asset) {
+        require(IERC20(_asset).decimals() == 18, "Payroll::constructor: asset must have 18 decimals");
         treasuryAddress = _treasuryAddress;
         governance = _governance;
         asset = IERC20(_asset);

--- a/src/Payroll.sol
+++ b/src/Payroll.sol
@@ -23,8 +23,8 @@ contract Payroll {
         uint256 endTime;
     }
 
-    event SetRecipient(address recipient, uint256 amount, uint256 endTime);
-    event AmountWithdrawn(address recipient, uint256 amount);
+    event SetRecipient(address indexed recipient, uint256 amount, uint256 endTime);
+    event AmountWithdrawn(address indexed recipient, uint256 amount);
 
     constructor(address _treasuryAddress, address _governance, address _asset) {
         require(IERC20(_asset).decimals() == 18, "Payroll::constructor: asset must have 18 decimals");

--- a/src/Payroll.sol
+++ b/src/Payroll.sol
@@ -11,7 +11,7 @@ contract Payroll {
 
     address public immutable treasuryAddress;
     address public immutable governance;
-    IERC20 public immutable DOLA;
+    IERC20 public immutable asset;
     
     uint256 public constant SECONDS_PER_YEAR = 365 days;
 
@@ -24,10 +24,10 @@ contract Payroll {
     event SetRecipient(address recipient, uint256 amount, uint256 endTime);
     event AmountWithdrawn(address recipient, uint256 amount);
 
-    constructor(address _treasuryAddress, address _governance, address _DOLA) {
+    constructor(address _treasuryAddress, address _governance, address _asset) {
         treasuryAddress = _treasuryAddress;
         governance = _governance;
-        DOLA = IERC20(_DOLA);
+        asset = IERC20(_asset);
     }
 
     function balanceOf(address _recipient) public view returns (uint256 bal) {
@@ -45,8 +45,8 @@ contract Payroll {
 
     function setRecipient(address _recipient, uint256 _yearlyAmount, uint256 _endTime) external {
         updateRecipient(_recipient);
-        require(msg.sender == governance, "DolaPayroll::setRecipient: only governance");
-        require(_recipient != address(0), "DolaPayroll::setRecipient: zero address!");
+        require(msg.sender == governance, "Payroll::setRecipient: only governance");
+        require(_recipient != address(0), "Payroll::setRecipient: zero address!");
 
         // endTime cannot be in the past
         if(_endTime < block.timestamp) {
@@ -70,7 +70,7 @@ contract Payroll {
 
         uint256 withdrawAmount = unclaimed[msg.sender] > amount ? amount : unclaimed[msg.sender];
         unclaimed[msg.sender] -= withdrawAmount;
-        require(DOLA.transferFrom(treasuryAddress, msg.sender, withdrawAmount), "DolaPayroll::withdraw: transfer failed");
+        require(asset.transferFrom(treasuryAddress, msg.sender, withdrawAmount), "Payroll::withdraw: transfer failed");
 
         emit AmountWithdrawn(msg.sender, withdrawAmount);
     }

--- a/src/Payroll.sol
+++ b/src/Payroll.sol
@@ -22,7 +22,6 @@ contract Payroll {
     }
 
     event SetRecipient(address recipient, uint256 amount, uint256 endTime);
-    event RecipientRemoved(address recipient);
     event AmountWithdrawn(address recipient, uint256 amount);
 
     constructor(address _treasuryAddress, address _governance, address _DOLA) {

--- a/src/Payroll.sol
+++ b/src/Payroll.sol
@@ -1,0 +1,83 @@
+pragma solidity 0.8.13;
+
+interface IERC20 {
+    function transferFrom(address from, address to, uint256 amount) external returns (bool);
+}
+
+contract Payroll {
+
+    mapping(address => Recipient) public recipients;
+    mapping(address => uint256) public unclaimed;
+
+    address public immutable treasuryAddress;
+    address public immutable governance;
+    IERC20 public immutable DOLA;
+    
+    uint256 public constant SECONDS_PER_YEAR = 365 days;
+
+    struct Recipient {
+        uint256 lastClaim;
+        uint256 ratePerSecond;
+        uint256 endTime;
+    }
+
+    event SetRecipient(address recipient, uint256 amount, uint256 endTime);
+    event RecipientRemoved(address recipient);
+    event AmountWithdrawn(address recipient, uint256 amount);
+
+    constructor(address _treasuryAddress, address _governance, address _DOLA) {
+        treasuryAddress = _treasuryAddress;
+        governance = _governance;
+        DOLA = IERC20(_DOLA);
+    }
+
+    function balanceOf(address _recipient) public view returns (uint256 bal) {
+        bal = unclaimed[_recipient];
+        Recipient memory recipient = recipients[_recipient];
+        if (recipient.endTime > block.timestamp) {
+            // recipient is still active
+            bal += recipient.ratePerSecond * (block.timestamp - recipient.lastClaim);
+        } else {
+            // recipient is no longer active
+            bal += recipient.ratePerSecond * (recipient.endTime - recipient.lastClaim);
+        }
+    }
+
+    function updateRecipient(address recipient) internal {
+        unclaimed[recipient] = balanceOf(recipient);
+        recipients[recipient].lastClaim = block.timestamp;
+    }
+
+    function setRecipient(address _recipient, uint256 _yearlyAmount, uint256 _endTime) external {
+        updateRecipient(_recipient);
+        require(msg.sender == governance, "DolaPayroll::setRecipient: only governance");
+        require(_recipient != address(0), "DolaPayroll::setRecipient: zero address!");
+
+        // if endTime is in the past, set it to the current block timestamp to avoid underflow in balanceOf
+        if(_endTime < block.timestamp) {
+            _endTime = block.timestamp;
+        }
+
+        recipients[_recipient] = Recipient({
+            lastClaim: block.timestamp,
+            ratePerSecond: _yearlyAmount / SECONDS_PER_YEAR,
+            endTime: _endTime
+        });
+
+        emit SetRecipient(_recipient, _yearlyAmount, _endTime);
+    }
+
+    /**
+    * @notice withdraw salary
+    */
+    function withdraw() external {
+        updateRecipient(msg.sender);
+
+        uint256 amount = unclaimed[msg.sender];
+        unclaimed[msg.sender] = 0;        
+        require(DOLA.transferFrom(treasuryAddress, msg.sender, amount), "DolaPayroll::withdraw: transfer failed");
+
+        emit AmountWithdrawn(msg.sender, amount);
+    }
+
+}

--- a/test/Payroll.t.sol
+++ b/test/Payroll.t.sol
@@ -134,7 +134,7 @@ contract PayrollTest is Test {
         vm.prank(alice);
         vm.expectEmit(true, true, true, true);
         emit AmountWithdrawn(alice, expectedAmount);
-        payroll.withdraw();
+        payroll.withdraw(expectedAmount);
 
         uint256 treasuryAfter = dola.balanceOf(treasury);
         uint256 aliceAfter = dola.balanceOf(alice);

--- a/test/Payroll.t.sol
+++ b/test/Payroll.t.sol
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Test} from "forge-std/Test.sol";
+import {Payroll} from "../src/Payroll.sol";
+import {MockERC20} from "./utils/MockERC20.sol";
+
+contract PayrollTest is Test {
+    Payroll public payroll;
+    MockERC20 public dola;
+
+    address public governance;
+    address public treasury;
+    address public alice;
+    address public bob;
+
+    event SetRecipient(address recipient, uint256 amount, uint256 endTime);
+    event RecipientRemoved(address recipient);
+    event AmountWithdrawn(address recipient, uint256 amount);
+
+    function setUp() public {
+        governance = makeAddr("governance");
+        treasury = makeAddr("treasury");
+        alice = makeAddr("alice");
+        bob = makeAddr("bob");
+
+        dola = new MockERC20("DOLA", "DOLA");
+        dola.mint(treasury, 1_000_000 ether);
+
+        payroll = new Payroll(treasury, governance, address(dola));
+
+        vm.prank(treasury);
+        dola.approve(address(payroll), type(uint256).max);
+    }
+
+    function test_constructor_sets_immutables() public {
+        assertEq(payroll.treasuryAddress(), treasury);
+        assertEq(payroll.governance(), governance);
+        assertEq(address(payroll.DOLA()), address(dola));
+    }
+
+    function test_setRecipient_only_governance() public {
+        uint256 endTime = block.timestamp + 10;
+        vm.prank(alice);
+        vm.expectRevert(bytes("DolaPayroll::setRecipient: only governance"));
+        payroll.setRecipient(alice, 100, endTime);
+    }
+
+    function test_setRecipient_zero_address_reverts() public {
+        uint256 endTime = block.timestamp + 10;
+        vm.prank(governance);
+        vm.expectRevert(bytes("DolaPayroll::setRecipient: zero address!"));
+        payroll.setRecipient(address(0), 100, endTime);
+    }
+
+    function test_setRecipient_sets_fields_and_emits_event() public {
+        uint256 t0 = 1_000_000;
+        vm.warp(t0);
+
+        uint256 endTime = t0 + 10_000;
+        uint256 yearly = 365 days * 1_000; // ratePerSecond should be 1_000
+
+        vm.expectEmit(true, true, true, true);
+        emit SetRecipient(alice, yearly, endTime);
+
+        vm.prank(governance);
+        payroll.setRecipient(alice, yearly, endTime);
+
+        (uint256 lastClaim, uint256 ratePerSecond, uint256 end) = payroll.recipients(alice);
+        assertEq(lastClaim, t0);
+        assertEq(ratePerSecond, 1_000);
+        assertEq(end, endTime);
+    }
+
+    function test_setRecipient_past_end_normalized_to_now() public {
+        uint256 t0 = 2_000_000;
+        vm.warp(t0);
+
+        uint256 pastEnd = t0 - 1_234;
+        uint256 yearly = 365 days * 10;
+
+        vm.expectEmit(true, true, true, true);
+        emit SetRecipient(alice, yearly, t0);
+
+        vm.prank(governance);
+        payroll.setRecipient(alice, yearly, pastEnd);
+
+        (, uint256 ratePerSecond, uint256 end) = payroll.recipients(alice);
+        assertEq(ratePerSecond, 10);
+        assertEq(end, t0);
+    }
+
+    function test_balanceOf_during_active_period() public {
+        uint256 t0 = 3_000_000;
+        vm.warp(t0);
+        uint256 yearly = 365 days * 10; // rate 10/sec
+
+        vm.prank(governance);
+        payroll.setRecipient(alice, yearly, t0 + 10_000);
+
+        vm.warp(t0 + 1234); // 1234 seconds passed
+        uint256 bal = payroll.balanceOf(alice);
+        assertEq(bal, 10 * 1234);
+    }
+
+    function test_balanceOf_after_end_time() public {
+        uint256 t0 = 4_000_000;
+        vm.warp(t0);
+        uint256 yearly = 365 days * 10; // rate 10/sec
+
+        vm.prank(governance);
+        payroll.setRecipient(alice, yearly, t0 + 400);
+
+        vm.warp(t0 + 1_000); // past end
+        uint256 bal = payroll.balanceOf(alice);
+        // accrues only until end (400 seconds)
+        assertEq(bal, 10 * 400);
+    }
+
+    function test_withdraw_transfers_and_resets_unclaimed_and_emits_event() public {
+        uint256 t0 = 5_000_000;
+        vm.warp(t0);
+        uint256 yearly = 365 days * 20; // rate 20/sec
+
+        vm.prank(governance);
+        payroll.setRecipient(alice, yearly, t0 + 10_000);
+
+        vm.warp(t0 + 123);
+        uint256 expectedAmount = 20 * 123;
+
+        uint256 treasuryBefore = dola.balanceOf(treasury);
+        uint256 aliceBefore = dola.balanceOf(alice);
+
+        vm.prank(alice);
+        vm.expectEmit(true, true, true, true);
+        emit AmountWithdrawn(alice, expectedAmount);
+        payroll.withdraw();
+
+        uint256 treasuryAfter = dola.balanceOf(treasury);
+        uint256 aliceAfter = dola.balanceOf(alice);
+
+        assertEq(treasuryAfter, treasuryBefore - expectedAmount);
+        assertEq(aliceAfter, aliceBefore + expectedAmount);
+        assertEq(payroll.unclaimed(alice), 0);
+    }
+
+    function test_updateRecipient_accrues_prior_unclaimed_before_rate_change() public {
+        uint256 t0 = 6_000_000;
+        vm.warp(t0);
+        uint256 yearly1 = 365 days * 10; // 10/sec
+        uint256 yearly2 = 365 days * 20; // 20/sec
+
+        vm.prank(governance);
+        payroll.setRecipient(alice, yearly1, t0 + 10_000);
+
+        vm.warp(t0 + 100);
+        // Changing to a new rate; internal updateRecipient should accrue the first 100 * 10
+        vm.prank(governance);
+        payroll.setRecipient(alice, yearly2, t0 + 20_000);
+
+        // unclaimed should contain the accrued amount from the first schedule
+        assertEq(payroll.unclaimed(alice), 10 * 100);
+
+        // New accrual from the second schedule after lastClaim reset at t0+100
+        vm.warp(t0 + 150);
+        uint256 bal = payroll.balanceOf(alice);
+        // 100*10 (old) + 50*20 (new)
+        assertEq(bal, (10 * 100) + (20 * 50));
+    }
+}

--- a/test/Payroll.t.sol
+++ b/test/Payroll.t.sol
@@ -36,20 +36,20 @@ contract PayrollTest is Test {
     function test_constructor_sets_immutables() public {
         assertEq(payroll.treasuryAddress(), treasury);
         assertEq(payroll.governance(), governance);
-        assertEq(address(payroll.DOLA()), address(dola));
+        assertEq(address(payroll.asset()), address(dola));
     }
 
     function test_setRecipient_only_governance() public {
         uint256 endTime = block.timestamp + 10;
         vm.prank(alice);
-        vm.expectRevert(bytes("DolaPayroll::setRecipient: only governance"));
+        vm.expectRevert(bytes("Payroll::setRecipient: only governance"));
         payroll.setRecipient(alice, 100, endTime);
     }
 
     function test_setRecipient_zero_address_reverts() public {
         uint256 endTime = block.timestamp + 10;
         vm.prank(governance);
-        vm.expectRevert(bytes("DolaPayroll::setRecipient: zero address!"));
+        vm.expectRevert(bytes("Payroll::setRecipient: zero address!"));
         payroll.setRecipient(address(0), 100, endTime);
     }
 

--- a/test/utils/MockERC20.sol
+++ b/test/utils/MockERC20.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+contract MockERC20 {
+    string public name;
+    string public symbol;
+    uint8 public immutable decimals = 18;
+
+    uint256 public totalSupply;
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    constructor(string memory _name, string memory _symbol) {
+        name = _name;
+        symbol = _symbol;
+    }
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+        totalSupply += amount;
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        require(balanceOf[msg.sender] >= amount, "insufficient balance");
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        uint256 allowed = allowance[from][msg.sender];
+        require(allowed >= amount, "insufficient allowance");
+        require(balanceOf[from] >= amount, "insufficient balance");
+        if (allowed != type(uint256).max) {
+            allowance[from][msg.sender] = allowed - amount;
+        }
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+}
+
+


### PR DESCRIPTION
1. Simplified original payroll contract significantly. New contract has 2 functions only.
2. Added end time to recipients
3. Now accruing funds to `unclaimed` mapping instead of sending funds directly to address.
4. Removed `fundingCommitee` role
5. Added near full test coverage